### PR TITLE
Adapt code for new API

### DIFF
--- a/DebugGuiHook.cs
+++ b/DebugGuiHook.cs
@@ -2,12 +2,13 @@
 using System.Runtime.InteropServices;
 using UnityEngine;
 using ImGuiNET;
+using Unity.Entities;
 using VisualPinball.Unity.Game;
+using VisualPinball.Unity.Physics.DebugUI;
+using VisualPinball.Unity.VPT.Table;
 
 namespace VisualPinball.Engine.Unity.ImgGUI
 {
-    using Tools;
-
     [AddComponentMenu("Visual Pinball/Debug GUI")]
 	[DisallowMultipleComponent]
 	public class DebugGuiHook : MonoBehaviour
@@ -34,11 +35,6 @@ namespace VisualPinball.Engine.Unity.ImgGUI
 		private void Awake()
 		{
 			_controller = new ImGuiController();
-			if (base.enabled)
-			{
-				debugUI = new DebugUIClient();
-				DPProxy.debugUI = debugUI; // register IDebugUI
-			}
 		}
 
 		private void Start()
@@ -76,8 +72,8 @@ namespace VisualPinball.Engine.Unity.ImgGUI
 
 		// ============================================================
 
-		DebugUIClient debugUI = null;
-	
+		public DebugUIClient debugUI;
+
 		private void SubmitUI()
 		{
 			// here we create main debug window

--- a/DebugUI.cs
+++ b/DebugUI.cs
@@ -17,7 +17,7 @@ using UnityEditor;
 
 namespace VisualPinball.Engine.Unity.ImgGUI
 {
-    public class DebugUIClient : IDebugUINew
+    public class DebugUIClient : IDebugUI
     {
         const int _MaxSolenoidAnglesDataLength = 500;
         public int numFramesOnChart = 200;
@@ -36,7 +36,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
         {
             public List<float> onAngles = new List<float>();
             public List<float> offAngles = new List<float>();
-            public bool solenoid = false;            
+            public bool solenoid = false;
             public int onDuration = 0;
             public int offDuration = 0;
             public int duration = 0;
@@ -129,7 +129,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
         {
             if (ImGui.TreeNode("Flippers"))
             {
-                var sliders = EngineProvider<IPhysicsEngineNew>.Get().FlipperGetDebugSliders();
+                var sliders = EngineProvider<IPhysicsEngine>.Get().FlipperGetDebugSliders();
                 foreach (var slider in sliders) {
                     ImGui_SliderFloat(slider.Label, slider.Param, slider.MinValue, slider.MaxValue);
                 }
@@ -140,7 +140,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
                 }
 
                 var allFdds = _flippersDebugData.ToArray();
-                var allFss = EngineProvider<IPhysicsEngineNew>.Get().FlipperGetDebugStates();
+                var allFss = EngineProvider<IPhysicsEngine>.Get().FlipperGetDebugStates();
                 foreach (var fs in allFss) {
                     int fidx = _flipperToIdx[fs.Entity];
                     var name = _flipperNames[fs.Entity];
@@ -199,7 +199,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
             if (dist < epsilon)
             {
                 var pointOnPlayfieldSurface = ray.origin - ray.direction * dist;
-                EngineProvider<IPhysicsEngineNew>.Get().BallManualRoll(_lastCreatedBallEntityForManualBallRoller, pointOnPlayfieldSurface);
+                EngineProvider<IPhysicsEngine>.Get().BallManualRoll(_lastCreatedBallEntityForManualBallRoller, pointOnPlayfieldSurface);
             }
         }
 
@@ -219,7 +219,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
             var _allFdd = _flippersDebugData.ToArray();
 
             // read flipper states and create charts
-            var flippers = EngineProvider<IPhysicsEngineNew>.Get().FlipperGetDebugStates();
+            var flippers = EngineProvider<IPhysicsEngine>.Get().FlipperGetDebugStates();
             foreach (var fs in flippers) {
                 ref FlipperDebugData fdd = ref _allFdd[_flipperToIdx[fs.Entity]];
 
@@ -257,7 +257,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
         public void OnCreateBall(Entity entity)
         {
             if (entity == Entity.Null || entity.Index < 0) // not valid entity!
-                return; 
+                return;
             _lastCreatedBallEntityForManualBallRoller = entity;
             ++_ballCounter;
         }
@@ -265,7 +265,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI
         // ================================================================== Helpers ===
         void ImGui_SliderFloat(string label, DebugFlipperSliderParam param, float min, float max)
         {
-            var engine = EngineProvider<IPhysicsEngineNew>.Get();
+            var engine = EngineProvider<IPhysicsEngine>.Get();
             float val = engine.GetFlipperDebugValue(param);
             if (ImGui.SliderFloat(label, ref val, min, max))
             {

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -4,7 +4,7 @@ using ImGuiNET;
 namespace VisualPinball.Engine.Unity.ImgGUI.Tools
 {
 
-    internal class ChartFloat
+    public class ChartFloat
     {
         float[] _data;
         int _idx;
@@ -132,7 +132,7 @@ namespace VisualPinball.Engine.Unity.ImgGUI.Tools
         public T back {  get { return _buf[_tail]; } }
     }
 
-    struct FPSHelper
+    public struct FPSHelper
     {
         private bool _drawChart;
         private string _precision;


### PR DESCRIPTION
This PR updates the repo to work with ravarcade/VisualPinball.Engine#3.

The biggest change is that bootstrapping DebugUI has been changed. Before you had the component bootstrapping itself when enabled, now we have the `DebugUIClient` that is instantiated by the new `EngineProvider`. `DebugUIClient` then adds the component to the table game object if not already there.

Since it's your repo I've tried to touch as few lines as possible. For me there's still some clean-up to do, for example properly naming the classes ("Hook" and "Client" I found difficult to understand, I would rather call them `DebugUI` and `DebugUIBehavior` or `DebugUIComponent`), also putting members on top in the class makes it a lot more readable :)

Let me know if you want another "style cleanup" PR.